### PR TITLE
breaking changes in recipes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,12 +8,14 @@ Author: Brian J Smith [aut, cre]
 Maintainer: Brian J Smith <brian-j-smith@uiowa.edu>
 Description: Meta-package for statistical and machine learning with a common interface for model fitting, prediction, performance assessment, and presentation of results.  Supports predictive modeling of numerical, categorical, and censored time-to-event outcomes and resample (bootstrap and cross-validation) estimation of model performance.
 Imports: abind, foreach, ggplot2, Hmisc, irr, kernlab, magrittr, methods,
-         MLmetrics, ModelMetrics, party, recipes, rsample, Rsolnp, survival,
+         MLmetrics, ModelMetrics, party, recipes (>= 0.1.3.9002), rsample, Rsolnp, survival,
          survivalROC, utils
 Suggests: C50, doParallel, gbm, glmnet, kableExtra, knitr, MASS, nnet, pls,
           randomForest, rmarkdown, rms, testthat
+Remotes:
+    tidymodels/recipes
 License: GPL-3
 URL: https://github.com/brian-j-smith/MachineShop
 BugReports: https://github.com/brian-j-smith/MachineShop/issues
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.0.9000
 VignetteBuilder: knitr

--- a/R/utils.R
+++ b/R/utils.R
@@ -156,7 +156,7 @@ preprocess.default <- function(x, data, ...) {
 
 preprocess.recipe <- function(x, data, ...) {
   x <- prep(x, retain = TRUE)
-  if (is.null(data)) juice(x) else bake(x, newdata = data)
+  if (is.null(data)) juice(x) else bake(x, new_data = data)
 }
 
 


### PR DESCRIPTION
We'll be releasing a new version of `recipes` in the next week and there are a few breaking changes. See the [news file](https://tidymodels.github.io/recipes/dev/news/index.html) for details. We are trying to get the breaking changes out in one release; some are for upcoming features that aren't implemented yet and we didn't want to stagger them. 

The biggest changes are the differences in argument names in the new version, the most significant is `new_data` in stead of `newdata` in `prep`. 

The plan is to send `recipes` to CRAN next week (I hope) and send `caret` in once that is accepted. I will alert CRAN that other packages are affected and the maintainers have been notified. I'll update this thread once that process starts. 
